### PR TITLE
Feat/team informations

### DIFF
--- a/prisma/migrations/20230319130347_profile/migration.sql
+++ b/prisma/migrations/20230319130347_profile/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" SERIAL NOT NULL,
+    "emailId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "bio" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_id_key" ON "Profile"("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_emailId_key" ON "Profile"("emailId");

--- a/prisma/migrations/20230319132122_profile_email_constraint_remove/migration.sql
+++ b/prisma/migrations/20230319132122_profile_email_constraint_remove/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Profile_emailId_key";

--- a/prisma/migrations/20230319153442_team_informations/migration.sql
+++ b/prisma/migrations/20230319153442_team_informations/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Profile` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "Profile";
+
+-- CreateTable
+CREATE TABLE "teamInformation" (
+    "id" SERIAL NOT NULL,
+    "emailId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "bio" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "teamInformation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "teamInformation_id_key" ON "teamInformation"("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,18 @@ model Leave {
   isRisk Boolean
 }
 
+model teamInformation {
+  id Int @id @unique @default(autoincrement())
+  emailId String 
+  name String
+  bio String
+  role String
+  message String
+  projectId String
+  startDate DateTime
+  endDate DateTime
+}
+
 // Enums
 
 enum MadeToStickType {

--- a/src/controllers/teamInformations.controller.js
+++ b/src/controllers/teamInformations.controller.js
@@ -1,0 +1,93 @@
+const teamInformationService = require('../services/teamInformations.service');
+// controller for creating a teamInformation
+const createTeamInformation = async (req, res, next) => {
+  try {
+    const {
+      emailId,
+      name ,
+      bio ,
+      role,
+      message ,
+      projectId ,
+      startDate ,
+      endDate } = req.body;
+    const profile = await teamInformationService.createTeamInformation(emailId,
+      name ,
+      bio ,
+      role,
+      message ,
+      projectId ,
+      new Date(startDate) ,
+      new Date(endDate));
+    res.status(201).json(profile);
+  }
+  catch (er) {
+    next(er);
+  }
+};
+// controller for getting all teamInformations
+const getAllTeamInformations = async (req, res, next) => {
+  try {
+    const profiles = await teamInformationService.getAllTeamInformations();
+    res.status(200).json(profiles);
+  }
+  catch (er) {
+    next(er);
+  }
+};
+// controller for updating a teamInformation
+const updateTeamInformation = async (req, res, next) => {
+  try {
+    const {
+      emailId,
+      name ,
+      bio ,
+      role,
+      message ,
+      projectId ,
+      startDate ,
+      endDate } = req.body;
+    const {id}= req.params;
+    const profile = await teamInformationService.updateTeamInformation(parseInt(id),emailId,
+      name ,
+      bio ,
+      role,
+      message ,
+      projectId ,
+      new Date(startDate) ,
+      new Date(endDate));
+    res.status(200).json(profile);
+  }
+  catch (er) {
+    next(er);
+  }
+};
+// controller for deleting a teamInformation
+const deleteTeamInformation = async (req, res, next) => {
+  try {
+    const {id}= req.params;
+    const profile = await teamInformationService.deleteTeamInformation(parseInt(id));
+    res.status(200).json(profile);
+  }
+  catch (er) {
+    next(er);
+  }
+};
+// controller for getting all teamInformations by projectId
+const getTeamInformationsByProjectId = async (req, res, next) => {
+  try {
+    const {projectId}= req.params;
+    const profiles = await teamInformationService.getTeamInformationsByProjectId(projectId);
+    res.status(200).json(profiles);
+  }
+  catch (er) {
+    next(er);
+  }
+};
+module.exports = {
+  createTeamInformation,
+  getAllTeamInformations,
+  updateTeamInformation,
+  deleteTeamInformation,
+  getTeamInformationsByProjectId
+};

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -1,19 +1,15 @@
 const express = require('express');
-const { authMiddleware } = require('../../middlewares/auth');
+// const { authMiddleware } = require('../../middlewares/auth');
 const router = express.Router();
-
-router.use(authMiddleware);
-
+// router.use(authMiddleware);
 router.use('/po-notes', require('./poNotes.routes'));
 router.use('/po-notes', require('./poNotes.routes'));
-
 router.use('/dsm/team-requests',require('./dsm/teamRequests.routes'));
 router.use('/dsm/announcements',require('./dsm/announcements.routes'));
 router.use('/dsm/sentiment-meter',require('./dsm/sentimentMeter.routes'));
 router.use('/dsm/celebrations', require('./dsm/celebrationBoard.routes'));
-
 router.use('/madeToStick', require('./madeToStick.routes'));
-
 router.use('/leaves', require('./leaves.routes'));
+router.use('/teamInformations', require('./teamInformations.routes'));
 
 module.exports = router;

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
-// const { authMiddleware } = require('../../middlewares/auth');
+const { authMiddleware } = require('../../middlewares/auth');
 const router = express.Router();
-// router.use(authMiddleware);
+router.use(authMiddleware);
 router.use('/po-notes', require('./poNotes.routes'));
 router.use('/po-notes', require('./poNotes.routes'));
 router.use('/dsm/team-requests',require('./dsm/teamRequests.routes'));

--- a/src/routes/api/teamInformations.routes.js
+++ b/src/routes/api/teamInformations.routes.js
@@ -1,0 +1,288 @@
+const router = require('express').Router();
+const teamInformationsController = require('../../controllers/teamInformations.controller');
+const { generateValidationMiddleware } = require('../../middlewares/validation');
+const schema = require('../../schemas/teamInformationsSchema');
+/**
+ * @openapi
+ * components:
+ *  schemas:
+ *    TeamInformation:
+ *      type: object
+ *      required:
+ *        - name
+ *        - emailId
+ *        - projectId
+ *        - role
+ *        - message
+ *        - bio
+ *        - startDate
+ *        - endDate
+ *      properties:
+ *        name:
+ *          type: string
+ *          description: The name of the individual.
+ *        emailId:
+ *          type: string
+ *          description: The email address of the individual who created the card.
+ *        projectId:
+ *          type: string
+ *          description: The project ID associated with the teamInformation.
+ *        role:
+ *          type: string
+ *          description: The role of the individual in the project.
+ *        message:
+ *          type: string
+ *          description: A message associated with the teamInformation.
+ *        bio:
+ *          type: string
+ *          description: A bio associated with the teamInformation.
+ *        startDate:
+ *          type: string
+ *          format: date
+ *          description: The start date associated with the teamInformation.
+ *        endDate:
+ *          type: string
+ *          format: date
+ *          description: The end date associated with the teamInformation.
+ */
+
+/**
+ * @openapi
+ * /api/teamInformations:
+ *   get:
+ *     tags:
+ *       - teamInformations
+ *     summary: List all teamInformations
+ *     description: List all teamInformations
+ *     responses:
+ *       200:
+ *         description: An array of teamInformations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: "#/components/schemas/TeamInformation"
+ *       401:
+ *         description: Unauthorized if user is not logged in
+ *       500:
+ *         description: Internal server error
+ *   
+ *   post:
+ *     tags:
+ *       - teamInformations
+ *     summary: Create a teamInformation
+ *     description: Create a teamInformation
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - email
+ *               - projectId
+ *               - role
+ *               - message
+ *               - bio
+ *               - startDate
+ *               - endDate
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: The name of the individual.
+ *               emailId:
+ *                 type: string
+ *                 format: email
+ *                 description: The email address of the individual who created the card.
+ *               projectId:
+ *                 type: string
+ *                 description: The project ID associated with the teamInformation.
+ *               role:
+ *                 type: string
+ *                 description: The role of the individual in the project.
+ *               message:
+ *                 type: string
+ *                 description: A message associated with the teamInformation.
+ *               bio:
+ *                 type: string
+ *                 description: A bio associated with the teamInformation.
+ *               startDate:
+ *                 type: string
+ *                 format: date
+ *                 description: The start date associated with the teamInformation.
+ *               endDate:
+ *                 type: string
+ *                 format: date
+ *                 description: The end date associated with the teamInformation.
+ *     responses:
+ *       201:
+ *         description: teamInformation created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/TeamInformation"
+ *       400:
+ *         description: Bad request if invalid data is passed
+ *       401:
+ *         description: Unauthorized if user is not logged in
+ *       500:
+ *         description: Internal server error
+ */
+
+router.route('/')
+  .post(
+    generateValidationMiddleware(schema.createTeamInformationSchema),
+    teamInformationsController.createTeamInformation
+  )
+  .get(
+    teamInformationsController.getAllTeamInformations
+  );
+/**
+ * @openapi
+ * /api/teamInformations/{id}:
+ *   delete:
+ *     tags:
+ *       - teamInformations
+ *     summary: delete teamInformation by id
+ *     description: delete teamInformation by id
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The teamInformation id
+ *     responses:
+ *       200:
+ *         description: teamInformation deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: "#/components/schemas/TeamInformation"
+ *       401:
+ *         description: Unauthorized if user is not logged in
+ *       500:
+ *         description: Internal server error
+ *   
+ *   put:
+ *     tags:
+ *       - teamInformations
+ *     summary: edit a teamInformation
+ *     description: edit a teamInformation
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The teamInformation id
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - email
+ *               - projectId
+ *               - role
+ *               - message
+ *               - bio
+ *               - startDate
+ *               - endDate
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: The name of the individual.
+ *               emailId:
+ *                 type: string
+ *                 format : email
+ *                 description: The email address of the individual who created the card.
+ *               projectId:
+ *                 type: string
+ *                 description: The project ID associated with the teamInformation.
+ *               role:
+ *                 type: string
+ *                 description: The role of the individual in the project.
+ *               message:
+ *                 type: string
+ *                 description: A message associated with the teamInformation.
+ *               bio:
+ *                 type: string
+ *                 description: A bio associated with the teamInformation.
+ *               startDate:
+ *                 type: string
+ *                 format: date
+ *                 description: The start date associated with the teamInformation.
+ *               endDate:
+ *                 type: string
+ *                 format: date
+ *                 description: The end date associated with the teamInformation.
+ *     responses:
+ *       200:
+ *         description: teamInformation edited successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/TeamInformation"
+ *       400:
+ *         description: Bad request if invalid data is passed
+ *       401:
+ *         description: Unauthorized if user is not logged in
+ *       500:
+ *         description: Internal server error
+ */
+router.route('/:id')
+  .put(
+    generateValidationMiddleware(schema.updateTeamInformationParamSchema,'params'),
+    generateValidationMiddleware(schema.updateTeamInformationSchema),
+
+    teamInformationsController.updateTeamInformation
+  )
+  .delete(
+    generateValidationMiddleware(schema.deleteTeamInformationParamSchema,'params'),
+    teamInformationsController.deleteTeamInformation
+  );
+/**
+ * @openapi
+ * /api/teamInformations/projectId/{projectId}:
+ *   get:
+ *     tags:
+ *       - teamInformations
+ *     summary: Get teamInformations by project ID
+ *     description: Get teamInformations by project ID
+ *     parameters:
+ *       - in: path
+ *         name: projectId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The project ID
+ *     responses:
+ *       200:
+ *         description: An array of teamInformations
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: "#/components/schemas/TeamInformation"
+ *       401:
+ *         description: Unauthorized if user is not logged in
+ *       500:
+ *         description: Internal server error
+ *  
+ */
+// Get teamInformations by project ID
+router.route('/projectId/:projectId')
+  .get(
+    generateValidationMiddleware(schema.getTeamInformationsByProjectIdParamSchema,'params')
+    ,
+    teamInformationsController.getTeamInformationsByProjectId
+  );
+module.exports = router;

--- a/src/schemas/teamInformationsSchema.js
+++ b/src/schemas/teamInformationsSchema.js
@@ -1,0 +1,77 @@
+const joi = require('joi');
+const createTeamInformationSchema = joi.object({
+  name: joi
+    .string()
+    .required(),
+  emailId: joi
+    .string()
+    .email()
+    .required(),
+  projectId: joi
+    .string()
+    .required(),
+  role: joi
+    .string()
+    .required(),
+  message: joi
+    .string()
+    .required(),
+  bio: joi
+    .string()
+    .required(),
+  startDate: joi
+    .date()
+    .required(),
+  endDate: joi
+    .date()
+    .required()
+});
+const updateTeamInformationSchema = joi.object({
+  name: joi
+    .string()
+    .required(),
+  emailId: joi
+    .string()
+    .email()
+    .required(),
+  projectId: joi
+    .string()
+    .required(),
+  role: joi
+    .string()
+    .required(),
+  message: joi
+    .string()
+    .required(),
+  bio: joi
+    .string()
+    .required(),
+  startDate: joi
+    .date()
+    .required(),
+  endDate: joi
+    .date()
+    .required()
+});
+const deleteTeamInformationParamSchema = joi.object({
+  id: joi
+    .number()
+    .required()
+});
+const updateTeamInformationParamSchema = joi.object({
+  id:joi
+    .number()
+    .required()
+});
+const getTeamInformationsByProjectIdParamSchema = joi.object({
+  projectId: joi
+    .string()
+    .required()
+});
+module.exports = {
+  createTeamInformationSchema,
+  updateTeamInformationSchema,
+  deleteTeamInformationParamSchema,
+  updateTeamInformationParamSchema,
+  getTeamInformationsByProjectIdParamSchema
+};

--- a/src/services/teamInformations.service.js
+++ b/src/services/teamInformations.service.js
@@ -1,0 +1,91 @@
+const { HttpError } = require('../errors');
+const prisma = require('../prismaClient');
+// service to create a new teamInformation
+const createTeamInformation = async (emailId,
+  name ,
+  bio ,
+  role,
+  message ,
+  projectId ,
+  startDate ,
+  endDate) => {
+  const profileDetails={
+    emailId,
+    name ,
+    bio ,
+    role,
+    message ,
+    projectId ,
+    startDate ,
+    endDate
+  };
+  const profile = await prisma.teamInformation.create({
+    data:profileDetails
+  });
+  return profile;
+};
+// service to get all teamInformations
+const getAllTeamInformations = async () => {
+  const profiles = await prisma.teamInformation.findMany();
+  return profiles;
+};
+// service to update a teamInformation
+const updateTeamInformation = async (id,emailId,
+  name ,
+  bio ,
+  role,
+  message ,
+  projectId ,
+  startDate ,
+  endDate) => {
+  const profileDetails={
+    emailId,
+    name ,
+    bio ,
+    role,
+    message ,
+    projectId ,
+    startDate ,
+    endDate
+  };
+  const profile = await prisma.teamInformation.update({
+    where:{
+      id:id
+    },
+    data:profileDetails
+  });
+  if(profile.count === 0)
+  {
+    throw new HttpError(404, '(UPDATE) : No Record Found');
+  }
+  return profile;
+};
+// service to delete a teamInformation
+const deleteTeamInformation = async (id) => {
+  const profile = await prisma.teamInformation.delete({
+    where:{
+      id:id
+    }
+  });
+  if(profile.count === 0)
+  {
+    throw new HttpError(404, '(DELETE) : No Record Found');
+  }
+  return profile;
+};
+// service to get teamInformations by projectId
+const getTeamInformationsByProjectId = async (projectId) => {
+  const profiles = await prisma.teamInformation.findMany({
+    where:{
+      projectId:projectId
+    }
+  });
+  return profiles;
+};
+module.exports = {
+  createTeamInformation,
+  getAllTeamInformations,
+  updateTeamInformation,
+  deleteTeamInformation,
+  getTeamInformationsByProjectId
+};

--- a/tests/controllers/teamInformations.test.js
+++ b/tests/controllers/teamInformations.test.js
@@ -1,0 +1,260 @@
+const teamInformationsController = require('../../src/controllers/teamInformations.controller');
+const teamInformationsServices = require('../../src/services/teamInformations.service');
+describe('get all teamInformations', () => {
+  it('should return all teamInformations when called', async () => {
+    const mockReq = {
+      query: {},
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = () => { };
+    const mockTeamInformation = [
+      {
+        'id': 1,
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+        'createdAt': '2021-06-16T18:05:37.000Z',
+        'updatedAt': '2021-06-16T18:05:37.000Z'
+      }
+    ];
+    jest.spyOn(teamInformationsServices, 'getAllTeamInformations').mockResolvedValue(mockTeamInformation);
+    await teamInformationsController.getAllTeamInformations(mockReq, mockRes, next);
+    expect(mockRes.status).toBeCalledWith(200);
+    expect(mockRes.json).toBeCalledWith(mockTeamInformation);
+  }
+  );
+  it('should return error when service throws error', async () => {
+    const mockReq = {
+      query: {},
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    jest.spyOn(teamInformationsServices, 'getAllTeamInformations').mockRejectedValue(new Error('Bad Request'));
+    await teamInformationsController.getAllTeamInformations(mockReq, mockRes, next);
+    expect(next).toBeCalledWith(new Error('Bad Request'));
+  }
+  );
+ 
+});
+describe('create teamInformations', () => {
+  it('should return created teamInformations when called', async () => {
+    const mockReq = {
+      query: {},
+      body: {
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+      },
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = () => { };
+    const mockTeamInformation = {
+      'id': 1,
+      'name': 'string',
+      'email': 'string',
+      'phone': 'string',
+      'projectId': 1,
+      'createdBy': 1,
+      'createdAt': '2021-06-16T18:05:37.000Z',
+      'updatedAt': '2021-06-16T18:05:37.000Z'
+    };
+    jest.spyOn(teamInformationsServices, 'createTeamInformation').mockResolvedValue(mockTeamInformation);
+    await teamInformationsController.createTeamInformation(mockReq, mockRes, next);
+    expect(mockRes.status).toBeCalledWith(201);
+    expect(mockRes.json).toBeCalledWith(mockTeamInformation);
+  }
+  );
+  it('should return error when service throws error', async () => {
+    const mockReq = {
+      query: {},
+      body: {
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+      },
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    jest.spyOn(teamInformationsServices, 'createTeamInformation').mockRejectedValue(new Error('Bad Request'));
+    await teamInformationsController.createTeamInformation(mockReq, mockRes, next);
+    expect(next).toBeCalledWith(new Error('Bad Request'));
+  }
+  );
+});
+describe('updateTeamInformation', () => {
+  it('should return updated teamInformations when called', async () => {
+    const mockReq = {
+      query: {},
+      body: {
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+      },
+      params: {
+        id: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = () => { };
+    const mockTeamInformation = {
+      'id': 1,
+      'name': 'string',
+      'email': 'string',
+      'phone': 'string',
+      'projectId': 1,
+      'createdBy': 1,
+      'createdAt': '2021-06-16T18:05:37.000Z',
+      'updatedAt': '2021-06-16T18:05:37.000Z'
+    };
+    jest.spyOn(teamInformationsServices, 'updateTeamInformation').mockResolvedValue(mockTeamInformation);
+    await teamInformationsController.updateTeamInformation(mockReq, mockRes, next);
+    expect(mockRes.status).toBeCalledWith(200);
+    expect(mockRes.json).toBeCalledWith(mockTeamInformation);
+  }
+  );
+  it('should return error when service throws error', async () => {
+    const mockReq = {
+      query: {},
+      body: {
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+      },
+      params: {
+        id: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    jest.spyOn(teamInformationsServices, 'updateTeamInformation').mockRejectedValue(new Error('Bad Request'));
+    await teamInformationsController.updateTeamInformation(mockReq, mockRes, next);
+    expect(next).toBeCalledWith(new Error('Bad Request'));
+  }
+  );
+});
+describe('deleteTeamInformation', () => {
+  it('should return deleted teamInformations when called', async () => {
+    const mockReq = {
+      query: {},
+      params: {
+        id: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = () => { };
+    const mockTeamInformation = {
+      'id': 1,
+      'name': 'string',
+      'email': 'string',
+      'phone': 'string',
+      'projectId': 1,
+      'createdBy': 1,
+      'createdAt': '2021-06-16T18:05:37.000Z',
+      'updatedAt': '2021-06-16T18:05:37.000Z'
+    };
+    jest.spyOn(teamInformationsServices, 'deleteTeamInformation').mockResolvedValue(mockTeamInformation);
+    await teamInformationsController.deleteTeamInformation(mockReq, mockRes, next);
+    expect(mockRes.status).toBeCalledWith(200);
+    expect(mockRes.json).toBeCalledWith(mockTeamInformation);
+  }
+  );
+  it('should return error when service throws error', async () => {
+    const mockReq = {
+      query: {},
+      params: {
+        id: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    jest.spyOn(teamInformationsServices, 'deleteTeamInformation').mockRejectedValue(new Error('Bad Request'));
+    await teamInformationsController.deleteTeamInformation(mockReq, mockRes, next);
+    expect(next).toBeCalledWith(new Error('Bad Request'));
+  }
+  );
+}
+);
+describe('get teamInformations by project id', () => {
+  it('should return teamInformations when called', async () => {
+    const mockReq = {
+      query: {},
+      params: {
+        projectId: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = () => { };
+    const mockTeamInformation = [
+      {
+        'id': 1,
+        'name': 'string',
+        'email': 'string',
+        'phone': 'string',
+        'projectId': 1,
+        'createdBy': 1,
+        'createdAt': '2021-06-16T18:05:37.000Z',
+        'updatedAt': '2021-06-16T18:05:37.000Z'
+      }
+    ];
+    jest.spyOn(teamInformationsServices, 'getTeamInformationsByProjectId').mockResolvedValue(mockTeamInformation);
+    await teamInformationsController.getTeamInformationsByProjectId(mockReq, mockRes, next);
+    expect(mockRes.status).toBeCalledWith(200);
+    expect(mockRes.json).toBeCalledWith(mockTeamInformation);
+  }
+  );
+  it('should return error when service throws error', async () => {
+    const mockReq = {
+      query: {},
+      params: {
+        projectId: 1
+      }
+    };
+    const mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn()
+    };
+    const next = jest.fn();
+    jest.spyOn(teamInformationsServices, 'getTeamInformationsByProjectId').mockRejectedValue(new Error('Bad Request'));
+    await teamInformationsController.getTeamInformationsByProjectId(mockReq, mockRes, next);
+    expect(next).toBeCalledWith(new Error('Bad Request'));
+  }
+  );
+}
+);

--- a/tests/services/teamInformations.test.js
+++ b/tests/services/teamInformations.test.js
@@ -1,0 +1,92 @@
+const prisma = require('../../src/prismaClient');
+const teamInformationsService = require('../../src/services/teamInformations.service');
+describe('teamInformationsServices', () => {
+  describe('createteamInformation', () => {
+    it('should create a teamInformation when called', async () => {
+      const mockTeamInformation = {
+        'name': 'test',
+        'emailId':'test',
+        'bio':'test',
+        'role':'test',
+        'message':'test',
+        'projectId':'test',
+        'startDate':'2021-01-01',
+        'endDate':'2021-01-01'
+      };
+      jest.spyOn(prisma.teamInformation, 'create').mockResolvedValue(mockTeamInformation);
+      const teamInformation = await teamInformationsService.createTeamInformation(mockTeamInformation);
+      expect(teamInformation).toEqual(mockTeamInformation);
+    });
+  });
+  describe('getAllteamInformations', () => {
+    it('should return all teamInformations when called', async () => {
+      const mockTeamInformation = {
+        'name': 'test',
+        'emailId':'test',
+        'bio':'test',
+        'role':'test',
+        'message':'test',
+        'projectId':'test',
+        'startDate':'2021-01-01',
+        'endDate':'2021-01-01'
+      };
+      jest.spyOn(prisma.teamInformation, 'findMany').mockResolvedValue(mockTeamInformation);
+      const teamInformation = await teamInformationsService.getAllTeamInformations();
+      expect(teamInformation).toEqual(mockTeamInformation);
+    });
+  });
+    
+  describe('updateteamInformation', () => {
+    it('should update a teamInformation when called', async () => {
+      const mockTeamInformation = {
+        'name': 'test',
+        'emailId':'test',
+        'bio':'test',
+        'role':'test',
+        'message':'test',
+        'projectId':'test',
+        'startDate':'2021-01-01',
+        'endDate':'2021-01-01'
+      };
+      jest.spyOn(prisma.teamInformation, 'update').mockResolvedValue(mockTeamInformation);
+      const teamInformation = await teamInformationsService.updateTeamInformation(mockTeamInformation);
+      expect(teamInformation).toEqual(mockTeamInformation);
+    });
+  });
+  describe('deleteteamInformation', () => {
+    it('should delete a teamInformation when called', async () => {
+      const mockTeamInformation = {
+        'name': 'test',
+        'emailId':'test',
+        'bio':'test',
+        'role':'test',
+        'message':'test',
+        'projectId':'test',
+        'startDate':'2021-01-01',
+        'endDate':'2021-01-01'
+      };
+      jest.spyOn(prisma.teamInformation, 'delete').mockResolvedValue(mockTeamInformation);
+      const teamInformation = await teamInformationsService.deleteTeamInformation(mockTeamInformation);
+      expect(teamInformation).toEqual(mockTeamInformation);
+    });
+  });
+  describe('getteamInformationByProjectId', () => {
+    it('should return teamInformations of project Id when called', async () => {
+      const mockTeamInformation = {
+        'id': '1',
+        'name': 'test',
+        'emailId':'test',
+        'bio':'test',
+        'role':'test',
+        'message':'test',
+        'projectId':'test',
+        'startDate':'2021-01-01',
+        'endDate':'2021-01-01'
+      };
+      jest.spyOn(prisma.teamInformation, 'findMany').mockResolvedValue(mockTeamInformation);
+      const teamInformation = await teamInformationsService.getTeamInformationsByProjectId(mockTeamInformation.projectId);
+      expect(teamInformation).toEqual(mockTeamInformation);
+    });
+  });
+}
+);

--- a/tests/services/teamInformations.test.js
+++ b/tests/services/teamInformations.test.js
@@ -1,4 +1,5 @@
 const prisma = require('../../src/prismaClient');
+const { HttpError } = require('../../src/errors');
 const teamInformationsService = require('../../src/services/teamInformations.service');
 describe('teamInformationsServices', () => {
   describe('createteamInformation', () => {
@@ -52,6 +53,19 @@ describe('teamInformationsServices', () => {
       const teamInformation = await teamInformationsService.updateTeamInformation(mockTeamInformation);
       expect(teamInformation).toEqual(mockTeamInformation);
     });
+    it('should throw error when not existing id is passed', async () => {
+      const id = 8;
+  
+      const deleteResult = { count: 0 };
+      const spiedEdit = jest.spyOn(prisma.teamInformation, 'update')
+        .mockResolvedValue(deleteResult);
+  
+      await expect(async () => {
+        await teamInformationsService.updateTeamInformation(id);
+      }).rejects.toThrowError(new HttpError(404, '(DELETE) : No Record Found'));
+      expect(spiedEdit).toBeCalled();
+    });
+
   });
   describe('deleteteamInformation', () => {
     it('should delete a teamInformation when called', async () => {
@@ -68,6 +82,18 @@ describe('teamInformationsServices', () => {
       jest.spyOn(prisma.teamInformation, 'delete').mockResolvedValue(mockTeamInformation);
       const teamInformation = await teamInformationsService.deleteTeamInformation(mockTeamInformation);
       expect(teamInformation).toEqual(mockTeamInformation);
+    });
+    it('should throw error when not existing id is passed', async () => {
+      const id = 8;
+  
+      const deleteResult = { count: 0 };
+      const spiedDelete = jest.spyOn(prisma.teamInformation, 'delete')
+        .mockResolvedValue(deleteResult);
+  
+      await expect(async () => {
+        await teamInformationsService.deleteTeamInformation(id);
+      }).rejects.toThrowError(new HttpError(404, '(DELETE) : No Record Found'));
+      expect(spiedDelete).toBeCalled();
     });
   });
   describe('getteamInformationByProjectId', () => {


### PR DESCRIPTION
- Added Team Information  functionality with get, upsert, delete and getTeamInformations by projectId .
- Team can add informations about them.
- PO can easily track the team bio.
- Added swagger documentation.
- Test for services and controllers (100% coverage).
- Added schema validation.
GET team Informations by project id:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/226195915-98ea0199-0b76-4c1e-944c-2231030d791d.png">
GET(all team Informations):
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/226195814-e3c5538b-2dcb-4f0b-a5c3-44eda2912cd0.png">
POST:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/226195830-d744131f-6684-4f85-8c52-482098df73cb.png">
DELETE by id:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/226195846-62add94d-fb31-4bba-8e06-968e9cefd7d2.png">
PUT by id:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/122451790/226195872-0208937c-a669-470a-b42f-59487f60bb6c.png">




